### PR TITLE
ci: add `.*` to `allowedPostUpgradeCommands`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,5 +18,6 @@
     "taiga-family/renovate-config",
     "taiga-family/angular-contenteditable-accessor",
     "taiga-family/preview-landing-components"
-  ]
+  ],
+  "allowedPostUpgradeCommands": [".*"]
 }


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring
- [X] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behaviour?
* https://github.com/taiga-family/maskito/pull/819

## What is the new behaviour?
See:
* https://docs.renovatebot.com/self-hosted-configuration/#allowedpostupgradecommands
