### PR TITLE
fix: dont update major version of peer-dependency `libphonenumber-js`

### DIFF
--- a/default.json
+++ b/default.json
@@ -198,7 +198,8 @@
         "^@angular.*",
         "^@schematics.*",
         "^react.*",
-        "^vue.*"
+        "^vue.*",
+        "libphonenumber-js"
       ]
     }
   ]


### PR DESCRIPTION
Relates to:
* https://github.com/taiga-family/maskito/pull/1234