### PR TITLE
fix: don't bump dependencies inside overrides

### DIFF
--- a/default.json
+++ b/default.json
@@ -49,6 +49,10 @@
     },
     "packageRules": [
         {
+            "matchDepTypes": ["overrides"],
+            "enabled": false
+        },
+        {
             "matchDepTypes": ["devDependencies", "dependencies"],
             "rangeStrategy": "pin"
         },


### PR DESCRIPTION
Fixes https://github.com/taiga-family/renovate-config/issues/1671